### PR TITLE
Fix grid initialisation broken by #5

### DIFF
--- a/fall.lua
+++ b/fall.lua
@@ -1,4 +1,4 @@
--- fall (1.3.2)
+-- fall (1.3.3)
 --
 -- generative melodies
 --

--- a/lib/grid.lua
+++ b/lib/grid.lua
@@ -35,14 +35,18 @@ end
 
 FallGrid.init = function(remove_leaf_by_id, add_leaf)
   FallGrid.g = grid.connect()
-  GRID_WIDTH = FallGrid.g.device.cols + 1
-  GRID_HEIGHT = FallGrid.g.device.rows + 1
-  function FallGrid.g.key(x, y, z)
-    if z == 0 and y == GRID_HEIGHT - 1 then
-      remove_leaf_near(remove_leaf_by_id, x, y)
-    elseif z == 1 and y < GRID_HEIGHT - 1 then
-      add_leaf(grid_to_leaf_x(x), grid_to_leaf_y(y))
+  if FallGrid.g.device ~= nil then
+    GRID_WIDTH = FallGrid.g.device.cols + 1
+    GRID_HEIGHT = FallGrid.g.device.rows + 1
+    function FallGrid.g.key(x, y, z)
+      if z == 0 and y == GRID_HEIGHT - 1 then
+        remove_leaf_near(remove_leaf_by_id, x, y)
+      elseif z == 1 and y < GRID_HEIGHT - 1 then
+        add_leaf(grid_to_leaf_x(x), grid_to_leaf_y(y))
+      end
     end
+  else
+    FallGrid.g = nil
   end
 end
 

--- a/lib/grid.lua
+++ b/lib/grid.lua
@@ -2,8 +2,8 @@
 
 local NORNS_WIDTH = 128
 local NORNS_HEIGHT = 64
-local GRID_WIDTH
-local GRID_HEIGHT
+local GRID_WIDTH 
+local GRID_HEIGHT 
 local FallGrid = {}
 
 local function leaf_to_grid_x(value)
@@ -35,18 +35,14 @@ end
 
 FallGrid.init = function(remove_leaf_by_id, add_leaf)
   FallGrid.g = grid.connect()
-  if #(FallGrid.g) > 0 then
-    GRID_WIDTH = FallGrid.g.device.cols + 1
-    GRID_HEIGHT = FallGrid.g.device.rows + 1
-    function FallGrid.g.key(x, y, z)
-      if z == 0 and y == GRID_HEIGHT - 1 then
-        remove_leaf_near(remove_leaf_by_id, x, y)
-      elseif z == 1 and y < GRID_HEIGHT - 1 then
-        add_leaf(grid_to_leaf_x(x), grid_to_leaf_y(y))
-      end
+  GRID_WIDTH = FallGrid.g.device.cols + 1
+  GRID_HEIGHT = FallGrid.g.device.rows + 1
+  function FallGrid.g.key(x, y, z)
+    if z == 0 and y == GRID_HEIGHT - 1 then
+      remove_leaf_near(remove_leaf_by_id, x, y)
+    elseif z == 1 and y < GRID_HEIGHT - 1 then
+      add_leaf(grid_to_leaf_x(x), grid_to_leaf_y(y))
     end
-  else
-    FallGrid.g = nil
   end
 end
 


### PR DESCRIPTION
I thought I was counting `g.device` in #5 - sorry about that :(
This now tests whether `g.device` is null.

- [X] Tested with grid connected
- [X] Tested with no grid connected